### PR TITLE
Fix run-go-vet.sh

### DIFF
--- a/run-go-vet.sh
+++ b/run-go-vet.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -e
-pkg=$(go list)
-for dir in $(echo $@|xargs -n1 dirname|sort -u); do
-  go vet $pkg/$dir
+for dir in $(echo "$@"|xargs -n1 dirname|sort -u); do
+  go vet ./"$dir"
 done


### PR DESCRIPTION
Fix the run-go-vet.sh in a simpler way.

People have suggested other solution in: 
https://github.com/dnephin/pre-commit-golang/issues/30

But I found their solution still not works for my project, so I used a simpler way to handle it.

This script is tested locally by:
`pre-commit clean && pre-commit try-repo ../pre-commit-golang go-vet --verbose`
Should be okay after merging.